### PR TITLE
Increased spacing between Contributions' subtext and the 3d personal activity image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 # Contributions
 (in the last 365 days, languages pie based on number of commits)
+
 ![](./profile-3d-contrib/profile-green-animate.svg)
 
 # Projects


### PR DESCRIPTION
Small fix, increase the space between text and image